### PR TITLE
Addon attribute updates

### DIFF
--- a/heroku/models.py
+++ b/heroku/models.py
@@ -109,7 +109,8 @@ class Addon(AvailableAddon):
     """Heroku Addon."""
 
     _pks = ['name', 'type']
-    _strs = ['plan', 'name', 'description', 'url', 'state', 'attachment_name']
+    _strs = ['name', 'description', 'url', 'state', 'attachment_name', 'config_vars']
+    _dicts = ['plan']
 
     def __repr__(self):
         return "<addon '{0}'>".format(self.name)
@@ -250,7 +251,7 @@ class App(BaseResource):
             resource=('apps', self.name),
             obj=App,
         )
-        
+
     @property
     def labs(self):
         return self._h._get_resources(
@@ -608,14 +609,14 @@ class Feature(BaseResource):
     _strs = ['name', 'kind', 'summary', 'docs',]
     _bools = ['enabled']
     _pks = ['name']
-    
+
     def __init__(self):
         self.app = None
         super(Feature, self).__init__()
 
     def __repr__(self):
         return "<feature '{0}'>".format(self.name)
-    
+
     def enable(self):
         r = self._h._http_resource(
             method='POST',
@@ -623,7 +624,7 @@ class Feature(BaseResource):
             params={'app': self.app.name if self.app else ''}
         )
         return r.ok
-    
+
     def disable(self):
         r = self._h._http_resource(
             method='DELETE',

--- a/heroku/models.py
+++ b/heroku/models.py
@@ -95,14 +95,14 @@ class AvailableAddon(BaseResource):
 
     _strs = ['name', 'description', 'url', 'state']
     _bools = ['beta',]
-    _pks = ['plan']
+    _pks = ['name']
 
     def __repr__(self):
-        return "<available-addon '{0}'>".format(self.plan['name'])
+        return "<available-addon '{0}'>".format(self.name)
 
     @property
     def type(self):
-        return self.plan['name'].split(':')[0]
+        return self.name.split(':')[0]
 
 
 class Addon(AvailableAddon):
@@ -114,6 +114,10 @@ class Addon(AvailableAddon):
 
     def __repr__(self):
         return "<addon '{0}'>".format(self.name)
+
+    @property
+    def type(self):
+        return self.plan['name'].split(':')[0]
 
     def delete(self):
         addon_name = self.name


### PR DESCRIPTION
Few updates:
- The `AvailableAddon` class (which isn't actually used by itself right now as far as I can tell) is supposed to represent an addon resource that would be returned from `https://api.heroku.com/addon-services` (I believe). So `plan` is not a valid attribute, and can't be used as a _pk field regardless because its a dict.
- `Addon` represents an addon for an app, so `plan` is valid but should reside in _dict. Though thats its "proper" home, it ultimately doesn't matter from what I can tell.
- Added `config_vars` attribute to `Addon`.
