### PR TITLE
Add a method for retriving a specific app

### DIFF
--- a/heroku/api.py
+++ b/heroku/api.py
@@ -183,6 +183,9 @@ class Heroku(HerokuCore):
     def apps(self):
         return self._get_resources(('apps'), App)
 
+    def app(self, app_name):
+        return self._get_resource(('apps', app_name), App)
+
     @property
     def keys(self):
         return self._get_resources(('user', 'keys'), Key, map=SSHKeyListResource)


### PR DESCRIPTION
This is necessary to support app retrieval in situations where the app doesn't appear in the list of apps. This can happen when a user has too many apps to fit in a single page or when the app belongs to an organization, rather than a single user. It will still retrieve an app in standard situations as well.
